### PR TITLE
Fix badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple Model Context Protocol (MCP) server for [Clay](https://clay.earth).
 
 ## Getting Started
 ### Via Smithery (fastest)
-[![smithery badge](https://smithery.ai/badge/@clayhq/clay-mcp)](https://smithery.ai/server/@clayhq/clay-mcp)
+[![smithery badge](https://smithery.ai/badge/@clay-inc/clay-mcp)](https://smithery.ai/server/@clay-inc/clay-mcp)
 1. [Click here to log into Clay and generate your Clay API key](https://web.clay.earth/settings/api-keys).
 2. [Visit Clay's Smithery page](https://smithery.ai/server/@clay-inc/clay-mcp) and enter your Clay API key under "Installation".
 3. Under Claude > NPM, copy the NPM command and run it in your terminal.


### PR DESCRIPTION
The badge isn't pointing to the right URL